### PR TITLE
Fix data races and request handling in the LSP layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ Example
 
 ```go
 type Config struct {
-	Languages      *map[string][]Language `json:"languages,omitempty"`
-	LintDebounce   time.Duration          `json:"lintDebounce,omitempty"`
-	FormatDebounce time.Duration          `json:"formatDebounce,omitempty"`
+	Languages *map[string][]Language `json:"languages,omitempty"`
+	// how long a document must be idle before it is linted, in nanoseconds.
+	// defaults to 100ms; debouncing is per document
+	LintDebounce time.Duration `json:"lintDebounce,omitempty"`
 }
 
 type Language struct {

--- a/core/formatting.go
+++ b/core/formatting.go
@@ -20,15 +20,19 @@ var (
 	reEquals = regexp.MustCompile(`\$\{([^=}]+)=([^}]+)\}`)
 )
 
+// RunAllFormatters runs every configured formatter for uri in sequence, each
+// one fed the previous one's output, and returns the edits that turn the
+// document into the final result.
 func (h *LangHandler) RunAllFormatters(
-	ctx context.Context, uri types.DocumentURI, rng *types.Range, options types.FormattingOptions,
-	progress chan<- types.ProgressParams) ([]types.TextEdit, error) {
-	f, ok := h.files[uri]
-	if !ok {
-		return nil, fmt.Errorf("document not found: %v", uri)
+	ctx context.Context, reporter Reporter, uri types.DocumentURI, rng *types.Range,
+	options types.FormattingOptions) ([]types.TextEdit, error) {
+	snap, err := h.snapshot(uri)
+	if err != nil {
+		return nil, err
 	}
+	f := snap.file
 
-	configs, err := getFormatConfigsForDocument(f.NormalizedFilename, f.LanguageID, h.configs)
+	configs, err := getFormatConfigsForDocument(f.NormalizedFilename, f.LanguageID, snap.configs)
 	if err != nil {
 		return nil, err
 	}
@@ -38,10 +42,16 @@ func (h *LangHandler) RunAllFormatters(
 	}
 
 	progressToken := types.NewProgressToken()
-	progress <- types.ProgressParams{
+	reporter.Progress(ctx, types.ProgressParams{
 		Token: progressToken,
 		Value: types.NewWorkDoneProgressBegin("Formatting document", nil, nil),
-	}
+	})
+	// deferred so that an early return can never leave the client with a
+	// progress token that is begun but never ended
+	defer reporter.Progress(ctx, types.ProgressParams{
+		Token: progressToken,
+		Value: types.NewWorkDoneProgressEnd(nil),
+	})
 
 	originalText := f.Text
 	formattedText := originalText
@@ -49,7 +59,7 @@ func (h *LangHandler) RunAllFormatters(
 
 	errors := make([]string, 0)
 	for _, config := range configs {
-		rootPath := h.findRootPath(f.NormalizedFilename, config)
+		rootPath := findRootPath(f.NormalizedFilename, config.RootMarkers, snap.rootPath)
 		newText, err := formatDocument(ctx, rootPath, f.NormalizedFilename, formattedText, rng, options, config)
 
 		if err != nil {
@@ -66,12 +76,16 @@ func (h *LangHandler) RunAllFormatters(
 		return nil, fmt.Errorf("could not format for LanguageID: %s. All errors: %v", f.LanguageID, errors)
 	}
 
-	logs.Log.Logln(logs.Info, "format succeeded")
-
-	progress <- types.ProgressParams{
-		Token: progressToken,
-		Value: types.NewWorkDoneProgressEnd(nil),
+	// the edits below are a diff against the text the formatters started from, so
+	// they only apply cleanly to a document that has not moved since. a client
+	// that formats synchronously blocks input and cannot get here; one that
+	// formats asynchronously can, and applying a stale diff there would corrupt
+	// the document. a version comparison is cheap enough to do regardless.
+	if err := h.ensureUnchanged(uri, f.Version); err != nil {
+		return nil, err
 	}
+
+	logs.Log.Logln(logs.Info, "format succeeded")
 
 	return ComputeEdits(uri, originalText, formattedText)
 }

--- a/core/formatting_test.go
+++ b/core/formatting_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/konradmalik/flint-ls/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizedFilenameFromURI(t *testing.T) {
@@ -160,7 +162,7 @@ func TestRunFormattersRequireRootMatcher(t *testing.T) {
 	uri := ParseLocalFileToURI(filePath)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			"vim": {
 				{
@@ -183,8 +185,33 @@ func TestRunFormattersRequireRootMatcher(t *testing.T) {
 	assert.Empty(t, edits)
 }
 
+func TestRunFormattersEndsProgressWhenEveryFormatterFails(t *testing.T) {
+	testfile := filepath.Join(t.TempDir(), "text.txt")
+	uri := ParseLocalFileToURI(testfile)
+
+	h := &LangHandler{
+		files: map[types.DocumentURI]*fileRef{
+			uri: {Text: "hello", LanguageID: "go", NormalizedFilename: testfile},
+		},
+		configs: map[string][]types.Language{
+			"go": {{FormatCommand: "exit 1"}},
+		},
+	}
+
+	reporter := &recordingReporter{}
+	_, err := h.RunAllFormatters(t.Context(), reporter, uri, nil, types.FormattingOptions{})
+	require.Error(t, err)
+
+	// a failed run must still close its progress token, or the client is left
+	// showing a spinner forever
+	events := reporter.progressEvents()
+	require.Len(t, events, 2)
+	last, err := json.Marshal(events[1].Value)
+	require.NoError(t, err)
+	assert.Contains(t, string(last), `"kind":"end"`)
+	assert.Equal(t, events[0].Token, events[1].Token)
+}
+
 func (h *LangHandler) runAllFormatters(t *testing.T, uri types.DocumentURI) ([]types.TextEdit, error) {
-	progress := blackHoleProgress()
-	defer close(progress)
-	return h.RunAllFormatters(t.Context(), uri, nil, types.FormattingOptions{}, progress)
+	return h.RunAllFormatters(t.Context(), &recordingReporter{}, uri, nil, types.FormattingOptions{})
 }

--- a/core/handler.go
+++ b/core/handler.go
@@ -1,18 +1,27 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/konradmalik/flint-ls/types"
 )
 
+// LangHandler owns the document store and the language configuration.
+//
+// Document sync notifications arrive on the connection's read loop while lint
+// and format runs execute on their own goroutines, so every field below is
+// guarded by mu. Long running work must never hold mu: it takes a snapshot
+// first (see snapshot) and operates on that.
 type LangHandler struct {
+	mu       sync.RWMutex
 	configs  map[string][]types.Language
 	files    map[types.DocumentURI]*fileRef
-	RootPath string
+	rootPath string
 }
 
 type fileRef struct {
@@ -23,6 +32,57 @@ type fileRef struct {
 	Uri                types.DocumentURI
 }
 
+// documentSnapshot is a consistent, read-only view of everything a lint or
+// format run needs. It is copied out under LangHandler.mu so that concurrent
+// didChange/didClose notifications cannot mutate it mid-run.
+type documentSnapshot struct {
+	file     fileRef
+	configs  map[string][]types.Language
+	rootPath string
+}
+
+// ErrDocumentChanged reports that a document was edited while it was being
+// processed, which makes the result unusable: it describes a transformation of
+// text the client has already replaced. Only reachable from a client that does
+// not wait for the operation it asked for.
+var ErrDocumentChanged = errors.New("document changed while being processed")
+
+// ensureUnchanged reports whether uri still holds the version that was read at
+// the start of an operation. A document that has been closed counts as changed:
+// either way the result describes text the client no longer has, and the caller
+// has nothing else to decide.
+func (h *LangHandler) ensureUnchanged(uri types.DocumentURI, version int) error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	f, ok := h.files[uri]
+	if !ok {
+		return fmt.Errorf("%w: %v was closed", ErrDocumentChanged, uri)
+	}
+	if f.Version != version {
+		return fmt.Errorf("%w: %v moved from version %d to %d", ErrDocumentChanged, uri, version, f.Version)
+	}
+
+	return nil
+}
+
+// snapshot copies the state needed to process uri.
+//
+// The configs map is shared rather than cloned: UpdateConfiguration always
+// replaces the map wholesale and nothing mutates one in place, so a reader that
+// obtained the map under the lock can keep reading it without one.
+func (h *LangHandler) snapshot(uri types.DocumentURI) (documentSnapshot, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	f, ok := h.files[uri]
+	if !ok {
+		return documentSnapshot{}, fmt.Errorf("document not found: %v", uri)
+	}
+
+	return documentSnapshot{file: *f, configs: h.configs, rootPath: h.rootPath}, nil
+}
+
 func NewConfig() *types.Config {
 	languages := make(map[string][]types.Language)
 	return &types.Config{
@@ -31,20 +91,27 @@ func NewConfig() *types.Config {
 }
 
 func NewHandler(config *types.Config) *LangHandler {
-	handler := &LangHandler{
-		configs: *config.Languages,
+	configs := make(map[string][]types.Language)
+	if config.Languages != nil {
+		configs = *config.Languages
+	}
+
+	return &LangHandler{
+		configs: configs,
 		files:   make(map[types.DocumentURI]*fileRef),
 	}
-	return handler
 }
 
 func (h *LangHandler) Initialize(params types.InitializeParams) (types.InitializeResult, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	if params.RootURI != "" {
 		rootPath, err := PathFromURI(params.RootURI)
 		if err != nil {
 			return types.InitializeResult{}, err
 		}
-		h.RootPath = filepath.Clean(rootPath)
+		h.rootPath = filepath.Clean(rootPath)
 	}
 
 	var hasFormatCommand bool
@@ -81,12 +148,19 @@ func (h *LangHandler) Initialize(params types.InitializeParams) (types.Initializ
 }
 
 func (h *LangHandler) UpdateConfiguration(config *types.Config) {
-	if config.Languages != nil {
-		h.configs = *config.Languages
+	if config.Languages == nil {
+		return
 	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.configs = *config.Languages
 }
 
 func (h *LangHandler) CloseFile(uri types.DocumentURI) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	delete(h.files, uri)
 	return nil
 }
@@ -104,12 +178,18 @@ func (h *LangHandler) OpenFile(uri types.DocumentURI, languageID string, version
 		NormalizedFilename: fname,
 		Uri:                uri,
 	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.files[uri] = f
 
 	return nil
 }
 
 func (h *LangHandler) UpdateFile(uri types.DocumentURI, text string, version *int) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	f, ok := h.files[uri]
 	if !ok {
 		return fmt.Errorf("document not found: %v", uri)
@@ -122,12 +202,14 @@ func (h *LangHandler) UpdateFile(uri types.DocumentURI, text string, version *in
 	return nil
 }
 
-func (h *LangHandler) findRootPath(fname string, lang types.Language) string {
-	if dir := matchRootPath(fname, lang.RootMarkers); dir != "" {
+// findRootPath resolves the working directory for a tool invocation: the
+// closest ancestor directory matching one of the root markers, else fallback.
+func findRootPath(fname string, markers []string, fallback string) string {
+	if dir := matchRootPath(fname, markers); dir != "" {
 		return dir
 	}
 
-	return h.RootPath
+	return fallback
 }
 
 func matchRootPath(fname string, markers []string) string {

--- a/core/handler_test.go
+++ b/core/handler_test.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/konradmalik/flint-ls/types"
+)
+
+func TestNewHandlerWithoutLanguages(t *testing.T) {
+	h := NewHandler(&types.Config{})
+
+	_, err := h.snapshot("file:///nope")
+
+	assert.Error(t, err, "a handler without languages should be usable, just useless")
+}
+
+func TestEnsureUnchanged(t *testing.T) {
+	uri := types.DocumentURI("file:///a.txt")
+	h := &LangHandler{files: map[types.DocumentURI]*fileRef{uri: {Version: 7}}}
+
+	assert.NoError(t, h.ensureUnchanged(uri, 7))
+
+	assert.ErrorIs(t, h.ensureUnchanged(uri, 6), ErrDocumentChanged,
+		"a different version means the result is stale")
+
+	// closed and edited are the same answer to the caller: the result is unusable
+	assert.ErrorIs(t, h.ensureUnchanged("file:///gone.txt", 7), ErrDocumentChanged,
+		"a document that went away cannot be the one that was processed")
+}
+
+// TestConcurrentDocumentSyncWhileLinting covers the overlap the server lives
+// with: document sync notifications arrive on the connection's read loop while
+// lint and format runs execute on their own goroutines. Run under -race.
+func TestConcurrentDocumentSyncWhileLinting(t *testing.T) {
+	languages := map[string][]types.Language{
+		"test": {{
+			LintCommand:        "echo 1:problem",
+			LintFormats:        []string{"%l:%m"},
+			LintStdin:          true,
+			LintIgnoreExitCode: true,
+		}},
+	}
+	h := NewHandler(&types.Config{Languages: &languages})
+
+	uris := make([]types.DocumentURI, 4)
+	dir := t.TempDir()
+	for i := range uris {
+		uris[i] = ParseLocalFileToURI(filepath.Join(dir, string(rune('a'+i))+".txt"))
+		require.NoError(t, h.OpenFile(uris[i], "test", 1, "some text\n"))
+	}
+
+	const rounds = 20
+	var wg sync.WaitGroup
+
+	for _, uri := range uris {
+		wg.Go(func() {
+			for i := range rounds {
+				// the document may be closed right now by the goroutine below;
+				// that is an error, not a crash
+				_ = h.UpdateFile(uri, "changed text\n", &i)
+			}
+		})
+
+		wg.Go(func() {
+			for range rounds {
+				// a document may have been closed by the goroutine below, and
+				// linting a document that is gone is an error, not a crash
+				_ = h.RunAllLinters(t.Context(), &recordingReporter{}, uri, types.EventTypeChange)
+			}
+		})
+
+		wg.Go(func() {
+			for range rounds {
+				require.NoError(t, h.CloseFile(uri))
+				require.NoError(t, h.OpenFile(uri, "test", 1, "reopened\n"))
+			}
+		})
+	}
+
+	wg.Go(func() {
+		for range rounds {
+			h.UpdateConfiguration(&types.Config{Languages: &languages})
+		}
+	})
+
+	wg.Wait()
+}

--- a/core/linting.go
+++ b/core/linting.go
@@ -17,60 +17,61 @@ import (
 var unknownExitCode = -999
 var defaultLintFormats = []string{"%f:%l:%m", "%f:%l:%c:%m"}
 
-func (h *LangHandler) RunAllLinters(
-	ctx context.Context, uri types.DocumentURI, eventType types.EventType,
-	diagnosticsOut chan<- types.PublishDiagnosticsParams,
-	errorsOut chan<- error,
-	progress chan<- types.ProgressParams) error {
-	f, ok := h.files[uri]
-	if !ok {
-		return fmt.Errorf("document not found: %v", uri)
+// RunAllLinters lints uri with every configured linter that applies to
+// eventType, reporting diagnostics as each linter finishes. It blocks until all
+// linters are done or ctx is cancelled.
+func (h *LangHandler) RunAllLinters(ctx context.Context, reporter Reporter, uri types.DocumentURI, eventType types.EventType) error {
+	snap, err := h.snapshot(uri)
+	if err != nil {
+		return err
 	}
+	f := snap.file
 
-	configs := getLintConfigsForDocument(f.NormalizedFilename, f.LanguageID, h.configs, eventType)
+	configs := getLintConfigsForDocument(f.NormalizedFilename, f.LanguageID, snap.configs, eventType)
 	if len(configs) == 0 {
 		logs.Log.Logf(logs.Debug, "no matching lint configs for LanguageID: %v", f.LanguageID)
 		return nil
 	}
 
 	// to reset existing
-	diagnosticsOut <- types.PublishDiagnosticsParams{
+	reporter.PublishDiagnostics(ctx, types.PublishDiagnosticsParams{
 		URI:         uri,
 		Diagnostics: make([]types.Diagnostic, 0),
 		Version:     f.Version,
-	}
+	})
 
 	progressToken := types.NewProgressToken()
-	progress <- types.ProgressParams{
+	reporter.Progress(ctx, types.ProgressParams{
 		Token: progressToken,
 		Value: types.NewWorkDoneProgressBegin("Linting document", nil, nil),
-	}
+	})
+	// deferred so that an early return can never leave the client with a
+	// progress token that is begun but never ended
+	defer reporter.Progress(ctx, types.ProgressParams{
+		Token: progressToken,
+		Value: types.NewWorkDoneProgressEnd(nil),
+	})
 
 	var wg sync.WaitGroup
 	for _, config := range configs {
 		wg.Go(func() {
-			rootPath := h.findRootPath(f.NormalizedFilename, config)
-			diagnostics, err := lintDocument(ctx, rootPath, *f, config)
+			rootPath := findRootPath(f.NormalizedFilename, config.RootMarkers, snap.rootPath)
+			diagnostics, err := lintDocument(ctx, rootPath, f, config)
 			if err != nil {
 				logs.Log.Logln(logs.Error, err.Error())
-				errorsOut <- err
+				reporter.ReportError(ctx, err)
 				return
 			}
 
-			diagnosticsOut <- types.PublishDiagnosticsParams{
+			reporter.PublishDiagnostics(ctx, types.PublishDiagnosticsParams{
 				URI:         uri,
 				Diagnostics: diagnostics,
 				Version:     f.Version,
-			}
+			})
 		})
 	}
 
 	wg.Wait()
-
-	progress <- types.ProgressParams{
-		Token: progressToken,
-		Value: types.NewWorkDoneProgressEnd(nil),
-	}
 
 	return nil
 }

--- a/core/linting_test.go
+++ b/core/linting_test.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -117,7 +119,7 @@ func TestLinting(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &LangHandler{
-				RootPath: base,
+				rootPath: base,
 				configs: map[string][]types.Language{
 					"vim": {tt.langConfig},
 				},
@@ -143,7 +145,7 @@ func TestDiagnosticsResetOnEachRun(t *testing.T) {
 	uri := ParseLocalFileToURI(file)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			"vim": {
 				{
@@ -177,7 +179,7 @@ func TestLintFileMatchedWildcard(t *testing.T) {
 	uri := ParseLocalFileToURI(file)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			types.Wildcard: {
 				{
@@ -247,7 +249,7 @@ func TestLintOffsetColumns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &LangHandler{
-				RootPath: base,
+				rootPath: base,
 				configs: map[string][]types.Language{
 					types.Wildcard: {
 						{
@@ -289,7 +291,7 @@ func TestLintCategoryMap(t *testing.T) {
 	formats := []string{"%f:%l:%c:%t:%m"}
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			types.Wildcard: {
 				{
@@ -325,7 +327,7 @@ func TestLintRequireRootMarker(t *testing.T) {
 	uri := ParseLocalFileToURI(file)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			"vim": {
 				{
@@ -361,7 +363,7 @@ func TestLintSingleEntry(t *testing.T) {
 	uri2 := ParseLocalFileToURI(file2)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			"vim": {
 				{
@@ -403,7 +405,7 @@ func TestLintMultipleEntries(t *testing.T) {
 	uri2 := ParseLocalFileToURI(file2)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			"vim": {
 				{
@@ -445,7 +447,7 @@ func TestLintNoDiagnostics(t *testing.T) {
 	uri := ParseLocalFileToURI(file)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			"vim": {
 				{
@@ -477,7 +479,7 @@ func TestLintEventTypes(t *testing.T) {
 	uri := ParseLocalFileToURI(file)
 
 	h := &LangHandler{
-		RootPath: base,
+		rootPath: base,
 		configs: map[string][]types.Language{
 			"vim": {
 				{
@@ -870,40 +872,66 @@ func (h *LangHandler) getAllDiagnosticsForUriWithEvent(t *testing.T, uri types.D
 }
 
 func (h *LangHandler) getAllPublishDiagnosticsParamsForUriWithEvent(t *testing.T, uri types.DocumentURI, event types.EventType) ([]types.PublishDiagnosticsParams, error) {
-	var wg sync.WaitGroup
+	reporter := &recordingReporter{}
 
-	diagnosticsOut := make([]types.PublishDiagnosticsParams, 0)
-	errorsOut := make([]string, 0)
+	runErr := h.RunAllLinters(t.Context(), reporter, uri, event)
 
-	func() {
-		diagnosticsChan := make(chan types.PublishDiagnosticsParams)
-		errorsChan := make(chan error)
-		progressChan := blackHoleProgress()
-		defer close(diagnosticsChan)
-		defer close(errorsChan)
-		defer close(progressChan)
-
-		wg.Go(func() {
-			for e := range errorsChan {
-				errorsOut = append(errorsOut, e.Error())
-			}
-		})
-
-		wg.Go(func() {
-			for d := range diagnosticsChan {
-				diagnosticsOut = append(diagnosticsOut, d)
-			}
-		})
-
-		err := h.RunAllLinters(t.Context(), uri, event, diagnosticsChan, errorsChan, progressChan)
-		if err != nil {
-			errorsOut = append(errorsOut, err.Error())
-		}
-	}()
-
-	wg.Wait()
-	if len(errorsOut) != 0 {
-		return nil, fmt.Errorf("%s", strings.Join(errorsOut, ";"))
+	errs := reporter.errorMessages()
+	if runErr != nil {
+		errs = append(errs, runErr.Error())
 	}
-	return diagnosticsOut, nil
+
+	if len(errs) != 0 {
+		return nil, fmt.Errorf("%s", strings.Join(errs, ";"))
+	}
+	return reporter.publishedDiagnostics(), nil
+}
+
+// recordingReporter is a core.Reporter that accumulates everything reported to
+// it. Linters report from several goroutines at once, so it locks.
+type recordingReporter struct {
+	mu          sync.Mutex
+	diagnostics []types.PublishDiagnosticsParams
+	progress    []types.ProgressParams
+	errors      []error
+}
+
+func (r *recordingReporter) PublishDiagnostics(_ context.Context, params types.PublishDiagnosticsParams) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.diagnostics = append(r.diagnostics, params)
+}
+
+func (r *recordingReporter) Progress(_ context.Context, params types.ProgressParams) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.progress = append(r.progress, params)
+}
+
+func (r *recordingReporter) ReportError(_ context.Context, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errors = append(r.errors, err)
+}
+
+func (r *recordingReporter) publishedDiagnostics() []types.PublishDiagnosticsParams {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.diagnostics)
+}
+
+func (r *recordingReporter) progressEvents() []types.ProgressParams {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.progress)
+}
+
+func (r *recordingReporter) errorMessages() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	messages := make([]string, 0, len(r.errors))
+	for _, err := range r.errors {
+		messages = append(messages, err.Error())
+	}
+	return messages
 }

--- a/core/reporter.go
+++ b/core/reporter.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"context"
+
+	"github.com/konradmalik/flint-ls/types"
+)
+
+// Reporter receives the incremental results of a lint or format run.
+//
+// Linting and formatting shell out to external tools and can produce results
+// over time, so results are pushed to the client as they arrive instead of
+// being collected and returned at the end. Implementations must be safe for
+// concurrent use: a single run may report from several goroutines at once.
+type Reporter interface {
+	// PublishDiagnostics sends a complete set of diagnostics for one document.
+	PublishDiagnostics(ctx context.Context, params types.PublishDiagnosticsParams)
+	// Progress reports work-done progress for a long running operation.
+	Progress(ctx context.Context, params types.ProgressParams)
+	// ReportError surfaces a non-fatal error to the user. Errors are already
+	// written to the local log by the caller, so implementations should only
+	// forward them to the client.
+	ReportError(ctx context.Context, err error)
+}

--- a/core/utils.go
+++ b/core/utils.go
@@ -64,13 +64,3 @@ func boolOrDefault(b *bool, def bool) bool {
 	}
 	return *b
 }
-
-func blackHoleProgress() chan types.ProgressParams {
-	ch := make(chan types.ProgressParams)
-	go func() {
-		for range ch {
-			// discard values
-		}
-	}()
-	return ch
-}

--- a/lsp/dispatch.go
+++ b/lsp/dispatch.go
@@ -1,0 +1,46 @@
+package lsp
+
+import (
+	"context"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+// blockingRequests are the requests whose handler waits on an external tool
+// before it can answer, so running one on the read loop stalls the whole
+// connection until that tool exits.
+//
+// Only formatting qualifies. Linting shells out to external tools too, but it is
+// triggered by notifications whose handlers merely arm a timer and return, so
+// that work already happens off the read loop -- see ScheduleLinting.
+var blockingRequests = map[string]bool{
+	"textDocument/formatting":      true,
+	"textDocument/rangeFormatting": true,
+}
+
+// OffloadSlowRequests runs the requests that wait on external tools in their own
+// goroutine and keeps everything else on the connection's read loop.
+//
+// Everything else has to stay inline, because dispatching to goroutines loses
+// the order the client sent messages in, and that order is load-bearing:
+// document sync (didOpen/didChange/didClose) only reconstructs the right text
+// when applied in sequence, initialize has to be seen before the documents it
+// applies to, and shutdown has to be seen before exit. So an inline handler must
+// never block -- work that takes real time belongs on a goroutine of its own,
+// not on a dispatcher that would reorder the message that started it.
+func OffloadSlowRequests(handler jsonrpc2.Handler) jsonrpc2.Handler {
+	return offloadingHandler{handler}
+}
+
+type offloadingHandler struct {
+	jsonrpc2.Handler
+}
+
+func (h offloadingHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	if !req.Notif && blockingRequests[req.Method] {
+		go h.Handler.Handle(ctx, conn, req)
+		return
+	}
+
+	h.Handler.Handle(ctx, conn, req)
+}

--- a/lsp/handle_exit.go
+++ b/lsp/handle_exit.go
@@ -1,0 +1,19 @@
+package lsp
+
+import (
+	"context"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+// HandleExit ends the session. Closing the connection is what actually stops
+// the server: it releases main, which then exits with ExitCode.
+func (h *LspHandler) HandleExit(_ context.Context, conn *jsonrpc2.Conn, _ *jsonrpc2.Request) (any, error) {
+	h.mu.Lock()
+	h.exitRequested = true
+	h.mu.Unlock()
+
+	h.Close()
+
+	return nil, conn.Close()
+}

--- a/lsp/handle_initialize.go
+++ b/lsp/handle_initialize.go
@@ -2,20 +2,15 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/konradmalik/flint-ls/types"
 )
 
-func (h *LspHandler) HandleInitialize(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result types.InitializeResult, err error) {
-	if req.Params == nil {
-		return types.InitializeResult{}, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.InitializeParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
+func (h *LspHandler) HandleInitialize(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (types.InitializeResult, error) {
+	params, err := decodeParams[types.InitializeParams](req)
+	if err != nil {
 		return types.InitializeResult{}, err
 	}
 

--- a/lsp/handle_shutdown.go
+++ b/lsp/handle_shutdown.go
@@ -6,7 +6,15 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LspHandler) HandleShutdown(_ context.Context, conn *jsonrpc2.Conn, _ *jsonrpc2.Request) (result any, err error) {
+// HandleShutdown stops all outstanding work and replies. The connection stays
+// open on purpose: the client is expected to follow up with exit, and closing
+// here would race that notification against our own response.
+func (h *LspHandler) HandleShutdown(_ context.Context, _ *jsonrpc2.Conn, _ *jsonrpc2.Request) (any, error) {
+	h.mu.Lock()
+	h.shutdownRequested = true
+	h.mu.Unlock()
+
 	h.Close()
-	return nil, conn.Close()
+
+	return nil, nil
 }

--- a/lsp/handle_textDocument_didChange.go
+++ b/lsp/handle_textDocument_didChange.go
@@ -2,30 +2,28 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/konradmalik/flint-ls/types"
-	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LspHandler) HandleTextDocumentDidChange(_ context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.DidChangeTextDocumentParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
+func (h *LspHandler) HandleTextDocumentDidChange(_ context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[types.DidChangeTextDocumentParams](req)
+	if err != nil {
 		return nil, err
 	}
 
-	for _, change := range params.ContentChanges {
-		if err := h.langHandler.UpdateFile(params.TextDocument.URI, change.Text, &params.TextDocument.Version); err != nil {
+	// the server announces full sync, so every change carries the whole
+	// document and only the last one matters
+	if n := len(params.ContentChanges); n > 0 {
+		text := params.ContentChanges[n-1].Text
+		if err := h.langHandler.UpdateFile(params.TextDocument.URI, text, &params.TextDocument.Version); err != nil {
 			return nil, err
 		}
 	}
 
-	notifier := NewNotifier(conn)
-	h.ScheduleLinting(*notifier, params.TextDocument.URI, types.EventTypeChange)
+	h.ScheduleLinting(NewNotifier(conn), params.TextDocument.URI, types.EventTypeChange)
 
 	return nil, nil
 }

--- a/lsp/handle_textDocument_didClose.go
+++ b/lsp/handle_textDocument_didClose.go
@@ -2,24 +2,25 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/konradmalik/flint-ls/types"
-	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LspHandler) HandleTextDocumentDidClose(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.DidCloseTextDocumentParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
+func (h *LspHandler) HandleTextDocumentDidClose(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[types.DidCloseTextDocumentParams](req)
+	if err != nil {
 		return nil, err
 	}
+
+	// drop scheduled work first: acting on a document that is no longer open
+	// would fail to find it anyway
+	h.ForgetDocument(params.TextDocument.URI)
 
 	if err := h.langHandler.CloseFile(params.TextDocument.URI); err != nil {
 		return nil, err
 	}
+
 	return nil, nil
 }

--- a/lsp/handle_textDocument_didOpen.go
+++ b/lsp/handle_textDocument_didOpen.go
@@ -2,28 +2,24 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/konradmalik/flint-ls/types"
-	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LspHandler) HandleTextDocumentDidOpen(_ context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.DidOpenTextDocumentParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
+func (h *LspHandler) HandleTextDocumentDidOpen(_ context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[types.DidOpenTextDocumentParams](req)
+	if err != nil {
 		return nil, err
 	}
 
-	if err := h.langHandler.OpenFile(params.TextDocument.URI, params.TextDocument.LanguageID, params.TextDocument.Version, params.TextDocument.Text); err != nil {
+	doc := params.TextDocument
+	if err := h.langHandler.OpenFile(doc.URI, doc.LanguageID, doc.Version, doc.Text); err != nil {
 		return nil, err
 	}
 
-	notifier := NewNotifier(conn)
-	h.ScheduleLinting(*notifier, params.TextDocument.URI, types.EventTypeOpen)
+	h.ScheduleLinting(NewNotifier(conn), doc.URI, types.EventTypeOpen)
 
 	return nil, nil
 }

--- a/lsp/handle_textDocument_didSave.go
+++ b/lsp/handle_textDocument_didSave.go
@@ -2,35 +2,27 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/konradmalik/flint-ls/types"
-	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LspHandler) HandleTextDocumentDidSave(_ context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.DidSaveTextDocumentParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
-		return nil, err
-	}
-
-	var event types.EventType
-	if params.Text != nil {
-		err = h.langHandler.UpdateFile(params.TextDocument.URI, *params.Text, nil)
-		event = types.EventTypeSave
-	} else {
-		event = types.EventTypeChange
-	}
+func (h *LspHandler) HandleTextDocumentDidSave(_ context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[types.DidSaveTextDocumentParams](req)
 	if err != nil {
 		return nil, err
 	}
 
-	notifier := NewNotifier(conn)
-	h.ScheduleLinting(*notifier, params.TextDocument.URI, event)
+	// the client only sends the text when it registered for it; without it our
+	// copy is already current thanks to didChange
+	if params.Text != nil {
+		if err := h.langHandler.UpdateFile(params.TextDocument.URI, *params.Text, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	h.ScheduleLinting(NewNotifier(conn), params.TextDocument.URI, types.EventTypeSave)
 
 	return nil, nil
 }

--- a/lsp/handle_textDocument_formatting.go
+++ b/lsp/handle_textDocument_formatting.go
@@ -2,36 +2,26 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/konradmalik/flint-ls/types"
-	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LspHandler) HandleTextDocumentFormatting(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.DocumentFormattingParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
+func (h *LspHandler) HandleTextDocumentFormatting(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[types.DocumentFormattingParams](req)
+	if err != nil {
 		return nil, err
 	}
 
-	notifier := NewNotifier(conn)
-	return h.Formatting(ctx, *notifier, params.TextDocument.URI, nil, params.Options)
+	return h.Formatting(ctx, NewNotifier(conn), params.TextDocument.URI, nil, params.Options)
 }
 
-func (h *LspHandler) HandleTextDocumentRangeFormatting(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.DocumentRangeFormattingParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
+func (h *LspHandler) HandleTextDocumentRangeFormatting(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[types.DocumentRangeFormattingParams](req)
+	if err != nil {
 		return nil, err
 	}
 
-	notifier := NewNotifier(conn)
-	return h.Formatting(ctx, *notifier, params.TextDocument.URI, &params.Range, params.Options)
+	return h.Formatting(ctx, NewNotifier(conn), params.TextDocument.URI, &params.Range, params.Options)
 }

--- a/lsp/handle_workspace_didChangeConfiguration.go
+++ b/lsp/handle_workspace_didChangeConfiguration.go
@@ -2,22 +2,19 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/konradmalik/flint-ls/types"
-	"github.com/sourcegraph/jsonrpc2"
 )
 
-func (h *LspHandler) HandleWorkspaceDidChangeConfiguration(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
-	var params types.DidChangeConfigurationParams
-	if err := json.Unmarshal(*req.Params, &params); err != nil {
+func (h *LspHandler) HandleWorkspaceDidChangeConfiguration(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[types.DidChangeConfigurationParams](req)
+	if err != nil {
 		return nil, err
 	}
 
 	h.UpdateConfiguration(&params.Settings)
+
 	return nil, nil
 }

--- a/lsp/handler.go
+++ b/lsp/handler.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -13,37 +14,112 @@ import (
 	"github.com/konradmalik/flint-ls/types"
 )
 
+// defaultLintDebounce coalesces the burst of didChange notifications an editor
+// sends while typing into a single lint run. Small enough to feel immediate,
+// large enough to avoid spawning a linter per keystroke.
+const defaultLintDebounce = 100 * time.Millisecond
+
+// codeContentModified tells the client its request was answered by state that
+// has since moved on, so the response should be disregarded rather than treated
+// as a failure. It is the standard code for a stale result.
+//
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage
+const codeContentModified = -32801
+
 type LspHandler struct {
-	langHandler    *core.LangHandler
-	formatMu       sync.Mutex
-	lintMu         sync.Mutex
-	lintTimer      *time.Timer
-	lintDebounce   time.Duration
-	formatTimer    *time.Timer
-	formatDebounce time.Duration
+	langHandler *core.LangHandler
+
+	// mu guards everything below it. It is never held across a lint or format
+	// run, only around the bookkeeping for one.
+	mu           sync.Mutex
+	lintDebounce time.Duration
+	lints        map[types.DocumentURI]*lintJob
+	// formats holds a job per document with formatting outstanding. Documents
+	// are independent, so they format in parallel; only same-document runs wait
+	// for each other.
+	formats           map[types.DocumentURI]*formatJob
+	shutdownRequested bool
+	exitRequested     bool
+	closed            bool
+}
+
+// lintJob tracks the pending and in-flight lint runs of a single document.
+// All fields are guarded by LspHandler.mu.
+type lintJob struct {
+	// timer fires the pending run; nil when nothing is pending.
+	timer *time.Timer
+	// cancel aborts the run currently executing; nil when none is.
+	cancel context.CancelFunc
+	// gen identifies the most recently scheduled run. A run that starts or
+	// finishes under a stale gen has been superseded and bails out.
+	gen uint64
+}
+
+// supersede invalidates the pending and in-flight runs of a document. The
+// caller must hold LspHandler.mu.
+func (job *lintJob) supersede() {
+	job.gen++
+	if job.timer != nil {
+		job.timer.Stop()
+		job.timer = nil
+	}
+	if job.cancel != nil {
+		job.cancel()
+		job.cancel = nil
+	}
+}
+
+// formatJob serializes the formatting of a single document.
+type formatJob struct {
+	// mu is held for the duration of a run. Two runs on the same document must
+	// not overlap: both would compute edits against the same original text, and
+	// formatters that rewrite the file in place would fight over it.
+	mu sync.Mutex
+	// requests counts the requests seen for this document, so a run waiting on
+	// mu can tell that a newer one has arrived. Guarded by LspHandler.mu.
+	requests uint64
+	// outstanding is how many requests still reference this job; the job is
+	// forgotten when the last one leaves. Guarded by LspHandler.mu.
+	outstanding int
+	// abandoned marks a document that was closed while requests were queued.
+	// Guarded by LspHandler.mu.
+	abandoned bool
 }
 
 func NewHandler(langHandler *core.LangHandler) *LspHandler {
-	return &LspHandler{langHandler: langHandler}
+	return &LspHandler{
+		langHandler:  langHandler,
+		lintDebounce: defaultLintDebounce,
+		lints:        make(map[types.DocumentURI]*lintJob),
+		formats:      make(map[types.DocumentURI]*formatJob),
+	}
 }
 
 func (h *LspHandler) UpdateConfiguration(config *types.Config) {
+	h.mu.Lock()
 	if config.LintDebounce > 0 {
 		h.lintDebounce = config.LintDebounce
 	}
-	if config.FormatDebounce > 0 {
-		h.formatDebounce = config.FormatDebounce
-	}
+	h.mu.Unlock()
 
 	h.langHandler.UpdateConfiguration(config)
 }
 
-func (h *LspHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+func (h *LspHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	// exit is the one message that must still be served after shutdown
+	if req.Method == "exit" {
+		return h.HandleExit(ctx, conn, req)
+	}
+
+	if h.isShuttingDown() {
+		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidRequest, Message: "server is shutting down"}
+	}
+
 	switch req.Method {
 	case "initialize":
 		return h.HandleInitialize(ctx, conn, req)
 	case "initialized":
-		return
+		return nil, nil
 	case "shutdown":
 		return h.HandleShutdown(ctx, conn, req)
 	case "textDocument/didOpen":
@@ -65,96 +141,216 @@ func (h *LspHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonr
 	return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: fmt.Sprintf("method not supported: %s", req.Method)}
 }
 
-func (h *LspHandler) Formatting(ctx context.Context, notifier LspNotifier, uri types.DocumentURI, rng *types.Range, opt types.FormattingOptions) ([]types.TextEdit, error) {
-	if h.formatTimer != nil {
-		logs.Log.Logf(logs.Debug, "format debounced: %v", h.formatDebounce)
-		return []types.TextEdit{}, nil
+// Formatting runs every configured formatter for uri and returns the edits that
+// bring the document to its formatted state.
+//
+// Documents format in parallel; requests for the same document wait for each
+// other. A request that finds a newer one queued for its document gives up
+// instead of shelling out: the edits it would compute are stale by construction,
+// and a client that spams formatting should cost one run, not one per request.
+// Saying so with an error keeps the client honest -- answering with an empty
+// edit list would instead claim the document needs no changes.
+func (h *LspHandler) Formatting(ctx context.Context, reporter core.Reporter, uri types.DocumentURI, rng *types.Range, opt types.FormattingOptions) ([]types.TextEdit, error) {
+	job, request := h.claimFormatting(uri)
+	defer h.releaseFormatting(uri, job)
+
+	job.mu.Lock()
+	defer job.mu.Unlock()
+
+	if h.formattingSuperseded(job, request) {
+		logs.Log.Logf(logs.Debug, "format for %v superseded", uri)
+		return nil, &jsonrpc2.Error{Code: codeContentModified, Message: "superseded by a newer formatting request"}
 	}
 
-	h.formatMu.Lock()
-	h.formatTimer = time.AfterFunc(h.formatDebounce, func() {
-		h.formatMu.Lock()
-		h.formatTimer = nil
-		h.formatMu.Unlock()
-	})
-	h.formatMu.Unlock()
+	edits, err := h.langHandler.RunAllFormatters(ctx, reporter, uri, rng, opt)
+	if errors.Is(err, core.ErrDocumentChanged) {
+		// the same answer as a superseded request: the client should disregard
+		// this response, not treat it as a formatter failure
+		logs.Log.Logf(logs.Debug, "format for %v raced an edit", uri)
+		return nil, &jsonrpc2.Error{Code: codeContentModified, Message: err.Error()}
+	}
 
-	progress := make(chan types.ProgressParams)
-	defer close(progress)
-
-	go func() {
-		for p := range progress {
-			notifier.Progress(ctx, p)
-		}
-	}()
-
-	return h.langHandler.RunAllFormatters(ctx, uri, rng, opt, progress)
+	return edits, err
 }
 
-var running = make(map[types.DocumentURI]context.CancelFunc)
+// claimFormatting registers a request against uri's job, creating the job if
+// this is the only request for that document, and returns the request's number.
+func (h *LspHandler) claimFormatting(uri types.DocumentURI) (*formatJob, uint64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-func (h *LspHandler) ScheduleLinting(notifier LspNotifier, uri types.DocumentURI, eventType types.EventType) {
-	if h.lintTimer != nil {
-		h.lintTimer.Reset(h.lintDebounce)
-		logs.Log.Logf(logs.Debug, "lint debounced: %v", h.formatDebounce)
+	job, ok := h.formats[uri]
+	if !ok {
+		job = &formatJob{}
+		h.formats[uri] = job
+	}
+	job.requests++
+	job.outstanding++
+
+	return job, job.requests
+}
+
+// formattingSuperseded reports whether the run for request should be skipped
+// because the server moved on while it waited for its turn.
+func (h *LspHandler) formattingSuperseded(job *formatJob, request uint64) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.closed || job.abandoned || job.requests != request
+}
+
+// releaseFormatting forgets a document once its last outstanding request is
+// done, so the map holds only documents being formatted right now.
+func (h *LspHandler) releaseFormatting(uri types.DocumentURI, job *formatJob) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	job.outstanding--
+	// the entry may already have been replaced by a job for a document that was
+	// closed and reopened, which must outlive this one
+	if job.outstanding == 0 && h.formats[uri] == job {
+		delete(h.formats, uri)
+	}
+}
+
+// ScheduleLinting queues a lint run for uri. Runs are debounced per document:
+// the run happens once uri has been quiet for the debounce interval, and any
+// run already in flight for uri is cancelled because its results are stale.
+func (h *LspHandler) ScheduleLinting(reporter core.Reporter, uri types.DocumentURI, eventType types.EventType) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed {
 		return
 	}
-	h.lintMu.Lock()
-	h.lintTimer = time.AfterFunc(h.lintDebounce, func() {
-		h.lintTimer = nil
 
-		h.lintMu.Lock()
-		cancel, ok := running[uri]
-		if ok {
-			cancel()
-		}
+	job, ok := h.lints[uri]
+	if !ok {
+		job = &lintJob{}
+		h.lints[uri] = job
+	}
+	job.supersede()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		running[uri] = cancel
-		h.lintMu.Unlock()
-
-		func() {
-			diagnostics := make(chan types.PublishDiagnosticsParams)
-			errors := make(chan error)
-			progress := make(chan types.ProgressParams)
-			defer close(diagnostics)
-			defer close(errors)
-			defer close(progress)
-
-			go func() {
-				for d := range diagnostics {
-					notifier.PublishDiagnostics(ctx, d)
-				}
-			}()
-
-			go func() {
-				for e := range errors {
-					logs.Log.Logln(logs.Error, e.Error())
-					notifier.LogMessage(ctx, types.MessError, e.Error())
-				}
-			}()
-
-			go func() {
-				for p := range progress {
-					notifier.Progress(ctx, p)
-				}
-			}()
-
-			err := h.langHandler.RunAllLinters(ctx, uri, eventType, diagnostics, errors, progress)
-			if err != nil {
-				logs.Log.Logln(logs.Error, err.Error())
-				notifier.LogMessage(ctx, types.MessError, err.Error())
-			}
-		}()
+	gen := job.gen
+	logs.Log.Logf(logs.Debug, "lint for %v scheduled in %v", uri, h.lintDebounce)
+	job.timer = time.AfterFunc(h.lintDebounce, func() {
+		h.runLinting(reporter, uri, job, gen, eventType)
 	})
-	h.lintMu.Unlock()
 }
 
+// ForgetDocument drops everything scheduled for uri. Used when a document is
+// closed: its diagnostics are no longer wanted, and formatting requests still
+// queued for it can no longer produce anything useful.
+func (h *LspHandler) ForgetDocument(uri types.DocumentURI) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if job, ok := h.lints[uri]; ok {
+		job.supersede()
+		delete(h.lints, uri)
+	}
+	if job, ok := h.formats[uri]; ok {
+		// requests still queued keep their reference to the job and clean it up
+		// themselves; the flag is what tells them to give up
+		job.abandoned = true
+		delete(h.formats, uri)
+	}
+}
+
+func (h *LspHandler) runLinting(reporter core.Reporter, uri types.DocumentURI, job *lintJob, gen uint64, eventType types.EventType) {
+	ctx, ok := h.startLinting(uri, job, gen)
+	if !ok {
+		return
+	}
+	defer h.finishLinting(uri, job, gen)
+
+	if err := h.langHandler.RunAllLinters(ctx, reporter, uri, eventType); err != nil {
+		logs.Log.Logln(logs.Error, err.Error())
+		reporter.ReportError(ctx, err)
+	}
+}
+
+// current reports whether job is still the run the handler expects for uri. The
+// generation alone is not enough: closing a document drops its job, and the one
+// installed when it is reopened starts counting again from the same numbers, so
+// a run left over from before the close would otherwise match it. Callers must
+// hold LspHandler.mu.
+func (h *LspHandler) current(uri types.DocumentURI, job *lintJob, gen uint64) bool {
+	return h.lints[uri] == job && job.gen == gen
+}
+
+// startLinting claims the run identified by gen and returns its context. It
+// reports false when a newer run has already superseded this one, which happens
+// when the timer fires just as another notification arrives.
+func (h *LspHandler) startLinting(uri types.DocumentURI, job *lintJob, gen uint64) (context.Context, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed || !h.current(uri, job, gen) {
+		return nil, false
+	}
+
+	// linting outlives the notification that triggered it, so it gets a context
+	// of its own instead of borrowing that notification's
+	ctx, cancel := context.WithCancel(context.Background())
+	job.timer = nil
+	job.cancel = cancel
+
+	return ctx, true
+}
+
+// finishLinting releases the run's context and forgets the document once
+// nothing is scheduled for it, so the map does not grow with every file opened.
+func (h *LspHandler) finishLinting(uri types.DocumentURI, job *lintJob, gen uint64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.current(uri, job, gen) {
+		// superseded: whoever took over already cancelled our context
+		return
+	}
+
+	if job.cancel != nil {
+		job.cancel()
+		job.cancel = nil
+	}
+	if job.timer == nil {
+		delete(h.lints, uri)
+	}
+}
+
+func (h *LspHandler) isShuttingDown() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.shutdownRequested
+}
+
+// ExitCode reports the process exit status the client asked for: the spec wants
+// 1 when exit arrives without a preceding shutdown, 0 otherwise. A connection
+// that simply goes away is not an error.
+func (h *LspHandler) ExitCode() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.exitRequested && !h.shutdownRequested {
+		return 1
+	}
+	return 0
+}
+
+// Close abandons all scheduled work and refuses to schedule more. It does not
+// wait for in-flight linters: their contexts are cancelled, which kills the
+// external processes, and their results are discarded.
 func (h *LspHandler) Close() {
-	if h.formatTimer != nil {
-		h.formatTimer.Stop()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.closed = true
+	for uri, job := range h.lints {
+		job.supersede()
+		delete(h.lints, uri)
 	}
-	if h.lintTimer != nil {
-		h.lintTimer.Stop()
-	}
+	// formatting requests still queued check closed and give up rather than
+	// shell out on the way down; they drop their own jobs as they unwind
 }

--- a/lsp/handler_test.go
+++ b/lsp/handler_test.go
@@ -1,0 +1,640 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/jsonrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/konradmalik/flint-ls/core"
+	"github.com/konradmalik/flint-ls/types"
+)
+
+const testLanguageID = "test"
+
+// neverFires is long enough that a scheduled run cannot go off while a test
+// inspects the handler's state, which keeps those tests free of sleeps.
+const neverFires = time.Hour
+
+func TestScheduleLintingKeepsOnePendingRunPerDocument(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+	reporter := &fakeReporter{}
+	a := newTestDocument(t, h, "a.txt")
+	b := newTestDocument(t, h, "b.txt")
+
+	h.ScheduleLinting(reporter, a, types.EventTypeOpen)
+	h.ScheduleLinting(reporter, b, types.EventTypeChange)
+
+	// documents must be debounced independently: a single shared timer would
+	// let an edit in b discard the run queued for a
+	assert.Len(t, h.pendingLints(), 2)
+}
+
+func TestScheduleLintingSupersedesEarlierRunOfSameDocument(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+	reporter := &fakeReporter{}
+	uri := newTestDocument(t, h, "a.txt")
+
+	for range 5 {
+		h.ScheduleLinting(reporter, uri, types.EventTypeChange)
+	}
+
+	pending := h.pendingLints()
+	require.Len(t, pending, 1)
+	assert.EqualValues(t, 5, pending[uri].gen, "each schedule should invalidate the previous one")
+}
+
+func TestScheduleLintingLintsEveryDocument(t *testing.T) {
+	h := newTestHandler(t, time.Millisecond)
+	reporter := &fakeReporter{}
+	a := newTestDocument(t, h, "a.txt")
+	b := newTestDocument(t, h, "b.txt")
+
+	h.ScheduleLinting(reporter, a, types.EventTypeOpen)
+	h.ScheduleLinting(reporter, b, types.EventTypeChange)
+
+	for _, uri := range []types.DocumentURI{a, b} {
+		assert.Eventually(t, func() bool {
+			return len(reporter.diagnosticsFor(uri)) == 1
+		}, time.Second, time.Millisecond, "no diagnostics published for %v", uri)
+	}
+	assert.Empty(t, reporter.reportedErrors())
+}
+
+func TestLintJobIsForgottenOnceItFinishes(t *testing.T) {
+	h := newTestHandler(t, time.Millisecond)
+	reporter := &fakeReporter{}
+	uri := newTestDocument(t, h, "a.txt")
+
+	h.ScheduleLinting(reporter, uri, types.EventTypeOpen)
+
+	// a document that is done linting must not be remembered, otherwise the
+	// handler grows by one live context per file touched in a session
+	assert.Eventually(t, func() bool {
+		return len(h.pendingLints()) == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestLintRunOfAReopenedDocumentSurvivesTheOldOne(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+	reporter := &fakeReporter{}
+	uri := newTestDocument(t, h, "a.txt")
+
+	// a run is scheduled and claims its turn
+	h.ScheduleLinting(reporter, uri, types.EventTypeOpen)
+	stale, staleGen := h.currentLintJob(t, uri)
+	_, ok := h.startLinting(uri, stale, staleGen)
+	require.True(t, ok)
+
+	// the document is closed and reopened, which installs a fresh job whose
+	// generation numbers start over from the same place
+	h.ForgetDocument(uri)
+	h.ScheduleLinting(reporter, uri, types.EventTypeOpen)
+	fresh, freshGen := h.currentLintJob(t, uri)
+	require.NotSame(t, stale, fresh)
+	require.Equal(t, staleGen, freshGen, "the collision this test is about")
+
+	freshCtx, ok := h.startLinting(uri, fresh, freshGen)
+	require.True(t, ok)
+
+	// the leftover run finishing must not disturb the new document's run
+	h.finishLinting(uri, stale, staleGen)
+
+	assert.NoError(t, freshCtx.Err(), "the reopened document's run was cancelled")
+	assert.Len(t, h.pendingLints(), 1, "the reopened document's job was dropped")
+}
+
+func TestForgetDocumentDropsScheduledRun(t *testing.T) {
+	h := newTestHandler(t, 10*time.Millisecond)
+	reporter := &fakeReporter{}
+	uri := newTestDocument(t, h, "a.txt")
+
+	h.ScheduleLinting(reporter, uri, types.EventTypeOpen)
+	h.ForgetDocument(uri)
+
+	assert.Empty(t, h.pendingLints())
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, reporter.diagnosticsFor(uri), "a cancelled run must not publish")
+}
+
+func TestCloseDropsScheduledRunsAndRefusesNewOnes(t *testing.T) {
+	h := newTestHandler(t, 10*time.Millisecond)
+	reporter := &fakeReporter{}
+	uri := newTestDocument(t, h, "a.txt")
+
+	h.ScheduleLinting(reporter, uri, types.EventTypeOpen)
+	h.Close()
+	h.ScheduleLinting(reporter, uri, types.EventTypeChange)
+
+	assert.Empty(t, h.pendingLints())
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, reporter.diagnosticsFor(uri))
+}
+
+func TestFormattingDropsSupersededRequests(t *testing.T) {
+	const requests = 20
+
+	h := newTestHandler(t, neverFires)
+	uri := newTestDocument(t, h, "a.txt")
+
+	// stand in for a run already under way, so every request below has to queue
+	// and can be superseded by the ones that arrive after it. holding the lock
+	// rather than leaning on a slow formatter is what makes the count exact.
+	inProgress, _ := h.claimFormatting(uri)
+	inProgress.mu.Lock()
+
+	type outcome struct {
+		edits []types.TextEdit
+		err   error
+	}
+	results := make([]outcome, requests)
+
+	var wg sync.WaitGroup
+	for i := range requests {
+		wg.Go(func() {
+			edits, err := h.Formatting(t.Context(), &fakeReporter{}, uri, nil, types.FormattingOptions{})
+			results[i] = outcome{edits, err}
+		})
+	}
+
+	// let every request register before any of them is allowed to run
+	require.Eventually(t, func() bool {
+		return h.formatRequestsSeen(uri) == requests+1
+	}, 10*time.Second, time.Millisecond, "not all requests registered")
+
+	inProgress.mu.Unlock()
+	h.releaseFormatting(uri, inProgress)
+	wg.Wait()
+
+	var formatted, superseded int
+	for _, got := range results {
+		if got.err == nil {
+			formatted++
+			assert.NotEmpty(t, got.edits, "a run that happened should return the edits it computed")
+			continue
+		}
+
+		var rpcErr *jsonrpc2.Error
+		require.ErrorAs(t, got.err, &rpcErr)
+		require.EqualValues(t, codeContentModified, rpcErr.Code,
+			"a superseded request must say so, not claim the document needs no edits")
+		superseded++
+	}
+
+	// a client that spams formatting costs one run, not one per request
+	assert.Equal(t, 1, formatted, "only the newest request should have been served")
+	assert.Equal(t, requests, formatted+superseded, "every request must get an answer")
+	assert.Empty(t, h.pendingFormats(), "the jobs must not outlive the burst")
+}
+
+func TestFormattingRunsDocumentsInParallel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the barrier below is written as a POSIX shell command")
+	}
+
+	const documents = 4
+
+	// this formatter only succeeds once every document has reached it, so the
+	// test cannot pass unless the runs genuinely overlap. it gives up after
+	// ~2s so that serialized formatting fails the test instead of hanging it.
+	barrier := filepath.Join(t.TempDir(), "arrived")
+	format := fmt.Sprintf(
+		`printf x >> %[1]s; n=200; `+
+			`while [ "$(wc -c < %[1]s)" -lt %[2]d ] && [ "$n" -gt 0 ]; do sleep 0.01; n=$((n-1)); done; `+
+			`[ "$(wc -c < %[1]s)" -ge %[2]d ] || exit 1; tr a-z A-Z`,
+		barrier, documents)
+
+	h := newTestHandlerWithLanguage(t, neverFires, types.Language{FormatCommand: format})
+
+	uris := make([]types.DocumentURI, documents)
+	for i := range uris {
+		uris[i] = newTestDocument(t, h, fmt.Sprintf("doc%d.txt", i))
+	}
+
+	errs := make([]error, documents)
+	var wg sync.WaitGroup
+	for i, uri := range uris {
+		wg.Go(func() {
+			_, errs[i] = h.Formatting(t.Context(), &fakeReporter{}, uri, nil, types.FormattingOptions{})
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "document %d did not format alongside the others", i)
+	}
+}
+
+// TestFormattingRejectsStaleEdits models a client that formats asynchronously
+// and so lets the document change under a running formatter. A synchronous
+// client cannot reach this, which is why the edit has to be injected by hand.
+func TestFormattingRejectsStaleEdits(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the barrier below is written as a POSIX shell command")
+	}
+
+	dir := t.TempDir()
+	started := filepath.Join(dir, "started")
+	release := filepath.Join(dir, "release")
+
+	// announces that it is running, then waits to be let go, so the edit below
+	// lands while the formatter is definitely mid-run
+	format := fmt.Sprintf(
+		`printf x > %[1]s; n=500; `+
+			`while [ ! -f %[2]s ] && [ "$n" -gt 0 ]; do sleep 0.01; n=$((n-1)); done; cat`,
+		started, release)
+
+	h := newTestHandlerWithLanguage(t, neverFires, types.Language{FormatCommand: format})
+	uri := newTestDocument(t, h, "a.txt")
+
+	type outcome struct {
+		edits []types.TextEdit
+		err   error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		edits, err := h.Formatting(t.Context(), &fakeReporter{}, uri, nil, types.FormattingOptions{})
+		done <- outcome{edits, err}
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(started)
+		return err == nil
+	}, 10*time.Second, time.Millisecond, "the formatter never started")
+
+	// what an async client allows: the buffer changes mid-format
+	version := 2
+	require.NoError(t, h.langHandler.UpdateFile(uri, "typed while formatting\n", &version))
+	require.NoError(t, os.WriteFile(release, nil, 0o600))
+
+	got := <-done
+
+	assert.Nil(t, got.edits, "stale edits must not reach the client")
+
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, got.err, &rpcErr)
+	assert.EqualValues(t, codeContentModified, rpcErr.Code,
+		"an edit that raced the formatter should be reported as stale, not as a formatter failure")
+}
+
+func TestFormattingServesSequentialRequests(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+	uri := newTestDocument(t, h, "a.txt")
+
+	// nothing to supersede: each request must be served on its own
+	for range 3 {
+		edits, err := h.Formatting(t.Context(), &fakeReporter{}, uri, nil, types.FormattingOptions{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, edits)
+	}
+
+	assert.Empty(t, h.pendingFormats())
+}
+
+func TestForgetDocumentDropsQueuedFormatting(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+	uri := newTestDocument(t, h, "a.txt")
+
+	job, request := h.claimFormatting(uri)
+	defer h.releaseFormatting(uri, job)
+	h.ForgetDocument(uri)
+
+	assert.True(t, h.formattingSuperseded(job, request),
+		"formatting a document that was closed cannot produce anything useful")
+	assert.Empty(t, h.pendingFormats())
+}
+
+func TestHandleRejectsRequestsAfterShutdown(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+
+	_, err := h.Handle(t.Context(), nil, &jsonrpc2.Request{Method: "shutdown"})
+	require.NoError(t, err)
+
+	_, err = h.Handle(t.Context(), nil, &jsonrpc2.Request{Method: "textDocument/formatting"})
+
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, jsonrpc2.CodeInvalidRequest, rpcErr.Code)
+}
+
+func TestHandleUnknownMethod(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+
+	_, err := h.Handle(t.Context(), nil, &jsonrpc2.Request{Method: "textDocument/hover"})
+
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, jsonrpc2.CodeMethodNotFound, rpcErr.Code)
+}
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		shutdown bool
+		exit     bool
+		want     int
+	}{
+		{name: "clean shutdown then exit", shutdown: true, exit: true, want: 0},
+		{name: "exit without shutdown", exit: true, want: 1},
+		{name: "connection dropped without exit", want: 0},
+		{name: "shutdown but no exit", shutdown: true, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandler(t, neverFires)
+			conn := newTestConn(t)
+
+			if tt.shutdown {
+				_, err := h.Handle(t.Context(), conn, &jsonrpc2.Request{Method: "shutdown"})
+				require.NoError(t, err)
+			}
+			if tt.exit {
+				_, err := h.Handle(t.Context(), conn, &jsonrpc2.Request{Method: "exit", Notif: true})
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, h.ExitCode())
+		})
+	}
+}
+
+func TestExitIsServedAfterShutdown(t *testing.T) {
+	h := newTestHandler(t, neverFires)
+	conn := newTestConn(t)
+
+	_, err := h.Handle(t.Context(), conn, &jsonrpc2.Request{Method: "shutdown"})
+	require.NoError(t, err)
+
+	// exit is the one message that must not be rejected once shutting down
+	_, err = h.Handle(t.Context(), conn, &jsonrpc2.Request{Method: "exit", Notif: true})
+	assert.NoError(t, err)
+}
+
+func TestDecodeParams(t *testing.T) {
+	t.Run("decodes params", func(t *testing.T) {
+		raw := json.RawMessage(`{"textDocument":{"uri":"file:///a.txt"}}`)
+
+		params, err := decodeParams[types.DidCloseTextDocumentParams](&jsonrpc2.Request{Params: &raw})
+
+		require.NoError(t, err)
+		assert.EqualValues(t, "file:///a.txt", params.TextDocument.URI)
+	})
+
+	t.Run("rejects missing params", func(t *testing.T) {
+		_, err := decodeParams[types.DidCloseTextDocumentParams](&jsonrpc2.Request{})
+
+		var rpcErr *jsonrpc2.Error
+		require.ErrorAs(t, err, &rpcErr)
+		assert.EqualValues(t, jsonrpc2.CodeInvalidParams, rpcErr.Code)
+	})
+
+	t.Run("rejects malformed params", func(t *testing.T) {
+		raw := json.RawMessage(`{"textDocument":42}`)
+
+		_, err := decodeParams[types.DidCloseTextDocumentParams](&jsonrpc2.Request{Params: &raw})
+
+		assert.Error(t, err)
+	})
+}
+
+func TestOffloadSlowRequests(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         jsonrpc2.Request
+		wantInline  bool
+		description string
+	}{
+		{
+			name:        "formatting is offloaded",
+			req:         jsonrpc2.Request{Method: "textDocument/formatting"},
+			description: "formatting waits on an external tool and must not block the read loop",
+		},
+		{
+			name:        "range formatting is offloaded",
+			req:         jsonrpc2.Request{Method: "textDocument/rangeFormatting"},
+			description: "formatting waits on an external tool and must not block the read loop",
+		},
+		{
+			name:        "document sync stays inline",
+			req:         jsonrpc2.Request{Method: "textDocument/didChange", Notif: true},
+			wantInline:  true,
+			description: "changes only reconstruct the text when applied in the order sent",
+		},
+		{
+			name:        "shutdown stays inline",
+			req:         jsonrpc2.Request{Method: "shutdown"},
+			wantInline:  true,
+			description: "a pipelined exit must not overtake the shutdown before it",
+		},
+		{
+			name:        "initialize stays inline",
+			req:         jsonrpc2.Request{Method: "initialize"},
+			wantInline:  true,
+			description: "documents opened right after must see the initialized state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocking := blockingHandler{entered: make(chan struct{}), release: make(chan struct{})}
+			handler := OffloadSlowRequests(blocking)
+			defer close(blocking.release)
+			entered, returned := blocking.entered, make(chan struct{})
+
+			go func() {
+				handler.Handle(t.Context(), nil, &tt.req)
+				close(returned)
+			}()
+			<-entered
+
+			// an inline handler cannot have returned while the work is blocked
+			select {
+			case <-returned:
+				assert.False(t, tt.wantInline, tt.description)
+			case <-time.After(50 * time.Millisecond):
+				assert.True(t, tt.wantInline, tt.description)
+			}
+		})
+	}
+}
+
+// blockingHandler stays inside Handle until released, which is what makes the
+// difference between inline and offloaded dispatch observable.
+type blockingHandler struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (h blockingHandler) Handle(context.Context, *jsonrpc2.Conn, *jsonrpc2.Request) {
+	close(h.entered)
+	<-h.release
+}
+
+// pendingLints copies the lint job table so tests can inspect it safely.
+func (h *LspHandler) pendingLints() map[types.DocumentURI]lintJob {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	jobs := make(map[types.DocumentURI]lintJob, len(h.lints))
+	for uri, job := range h.lints {
+		jobs[uri] = *job
+	}
+	return jobs
+}
+
+// currentLintJob returns the job the handler currently holds for uri.
+func (h *LspHandler) currentLintJob(t *testing.T, uri types.DocumentURI) (*lintJob, uint64) {
+	t.Helper()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	job, ok := h.lints[uri]
+	require.True(t, ok, "no lint job for %v", uri)
+
+	return job, job.gen
+}
+
+// pendingFormats lists the documents with formatting outstanding.
+func (h *LspHandler) pendingFormats() []types.DocumentURI {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return slices.Collect(maps.Keys(h.formats))
+}
+
+// formatRequestsSeen reports how many formatting requests uri's job has taken.
+func (h *LspHandler) formatRequestsSeen(uri types.DocumentURI) uint64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if job, ok := h.formats[uri]; ok {
+		return job.requests
+	}
+	return 0
+}
+
+func newTestHandler(t *testing.T, debounce time.Duration) *LspHandler {
+	t.Helper()
+
+	return newTestHandlerWithLanguage(t, debounce, types.Language{
+		LintCommand: "echo 1:problem",
+		// the linter reports no filename, so the entry is taken to be about the
+		// document that was linted
+		LintFormats:        []string{"%l:%m"},
+		LintStdin:          true,
+		LintIgnoreExitCode: true,
+		// changes the text, so a request that was served is distinguishable from
+		// one that produced nothing
+		FormatCommand: appendingFormatCommand(),
+	})
+}
+
+// appendingFormatCommand echoes the document back with a character appended.
+func appendingFormatCommand() string {
+	if runtime.GOOS == "windows" {
+		return `set /p line= && call echo %line%X`
+	}
+	return `echo "$(cat -)X"`
+}
+
+func newTestHandlerWithLanguage(t *testing.T, debounce time.Duration, language types.Language) *LspHandler {
+	t.Helper()
+
+	langHandler := core.NewHandler(&types.Config{
+		Languages: &map[string][]types.Language{testLanguageID: {language}},
+	})
+
+	h := NewHandler(langHandler)
+	h.UpdateConfiguration(&types.Config{LintDebounce: debounce})
+	t.Cleanup(h.Close)
+
+	return h
+}
+
+func newTestDocument(t *testing.T, h *LspHandler, name string) types.DocumentURI {
+	t.Helper()
+
+	uri := core.ParseLocalFileToURI(filepath.Join(t.TempDir(), name))
+	require.NoError(t, h.langHandler.OpenFile(uri, testLanguageID, 1, "some text\n"))
+
+	return uri
+}
+
+// newTestConn returns a live connection whose peer never answers. It is enough
+// for handlers that only need something to close.
+func newTestConn(t *testing.T) *jsonrpc2.Conn {
+	t.Helper()
+
+	client, server := net.Pipe()
+	noop := jsonrpc2.HandlerWithError(func(context.Context, *jsonrpc2.Conn, *jsonrpc2.Request) (any, error) {
+		return nil, nil
+	})
+	conn := jsonrpc2.NewConn(context.Background(),
+		jsonrpc2.NewBufferedStream(server, jsonrpc2.VSCodeObjectCodec{}), noop)
+
+	t.Cleanup(func() {
+		_ = conn.Close()
+		_ = client.Close()
+	})
+
+	return conn
+}
+
+// fakeReporter records what lint runs report. Linters report from several
+// goroutines at once, so it locks.
+type fakeReporter struct {
+	mu          sync.Mutex
+	diagnostics map[types.DocumentURI][]types.Diagnostic
+	errors      []error
+}
+
+func (r *fakeReporter) PublishDiagnostics(_ context.Context, params types.PublishDiagnosticsParams) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(params.Diagnostics) == 0 {
+		// the run's initial reset, not a result
+		return
+	}
+	if r.diagnostics == nil {
+		r.diagnostics = make(map[types.DocumentURI][]types.Diagnostic)
+	}
+	r.diagnostics[params.URI] = append(r.diagnostics[params.URI], params.Diagnostics...)
+}
+
+func (r *fakeReporter) Progress(context.Context, types.ProgressParams) {}
+
+func (r *fakeReporter) ReportError(_ context.Context, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.errors = append(r.errors, err)
+}
+
+func (r *fakeReporter) diagnosticsFor(uri types.DocumentURI) []types.Diagnostic {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.diagnostics[uri]
+}
+
+func (r *fakeReporter) reportedErrors() []error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.errors
+}

--- a/lsp/notifier.go
+++ b/lsp/notifier.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/sourcegraph/jsonrpc2"
 
+	"github.com/konradmalik/flint-ls/logs"
 	"github.com/konradmalik/flint-ls/types"
 )
 
+// LspNotifier sends server-initiated messages to the client. It implements
+// core.Reporter.
 type LspNotifier struct {
 	conn *jsonrpc2.Conn
 }
@@ -17,25 +20,28 @@ func NewNotifier(conn *jsonrpc2.Conn) *LspNotifier {
 }
 
 func (n *LspNotifier) LogMessage(ctx context.Context, typ types.MessageType, message string) {
-	_ = n.conn.Notify(
-		ctx,
-		"window/logMessage",
-		&types.LogMessageParams{
-			Type:    typ,
-			Message: message,
-		})
+	n.notify(ctx, "window/logMessage", &types.LogMessageParams{
+		Type:    typ,
+		Message: message,
+	})
 }
 
 func (n *LspNotifier) PublishDiagnostics(ctx context.Context, params types.PublishDiagnosticsParams) {
-	_ = n.conn.Notify(
-		ctx,
-		"textDocument/publishDiagnostics",
-		&params)
+	n.notify(ctx, "textDocument/publishDiagnostics", &params)
 }
 
 func (n *LspNotifier) Progress(ctx context.Context, params types.ProgressParams) {
-	_ = n.conn.Notify(
-		ctx,
-		"$/progress",
-		&params)
+	n.notify(ctx, "$/progress", &params)
+}
+
+func (n *LspNotifier) ReportError(ctx context.Context, err error) {
+	n.LogMessage(ctx, types.MessError, err.Error())
+}
+
+// notify is best-effort: a cancelled run or a closed connection makes the send
+// fail, and there is nothing to be done about it but leave a trace in the log.
+func (n *LspNotifier) notify(ctx context.Context, method string, params any) {
+	if err := n.conn.Notify(ctx, method, params); err != nil {
+		logs.Log.Logf(logs.Debug, "dropped %s notification: %v", method, err)
+	}
 }

--- a/lsp/params.go
+++ b/lsp/params.go
@@ -1,0 +1,23 @@
+package lsp
+
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+// decodeParams unmarshals the params of req into T, rejecting messages that
+// carry none. Every handler needs this, so it lives here instead of being
+// repeated per method.
+func decodeParams[T any](req *jsonrpc2.Request) (T, error) {
+	var params T
+
+	if req.Params == nil {
+		return params, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+	}
+	if err := json.Unmarshal(*req.Params, &params); err != nil {
+		return params, err
+	}
+
+	return params, nil
+}

--- a/main.go
+++ b/main.go
@@ -47,22 +47,21 @@ func main() {
 	logs.InitializeLogger(logfile, logs.LogLevel(max(loglevel, -1)))
 	logs.Log.Logln(logs.Info, "reading on stdin, writing on stdout")
 
-	var f *os.File
-	defer func() {
-		if f != nil {
-			_ = f.Close()
-		}
-	}()
-
 	internalHandler := core.NewHandler(config)
 	handler := lsp.NewHandler(internalHandler)
+
 	<-jsonrpc2.NewConn(
 		context.Background(),
 		jsonrpc2.NewBufferedStream(stdrwc{}, jsonrpc2.VSCodeObjectCodec{}),
-		jsonrpc2.HandlerWithError(handler.Handle),
+		lsp.OffloadSlowRequests(jsonrpc2.HandlerWithError(handler.Handle)),
 		jsonrpc2.LogMessages(logs.Log)).DisconnectNotify()
 
 	logs.Log.Logln(logs.Info, "flint-ls: connections closed")
+
+	// the client is gone: abandon anything still scheduled instead of letting
+	// pending linters run against a dead connection
+	handler.Close()
+	os.Exit(handler.ExitCode())
 }
 
 type stdrwc struct{}

--- a/types/core.go
+++ b/types/core.go
@@ -5,9 +5,9 @@ import "time"
 const Wildcard = "="
 
 type Config struct {
-	Languages      *map[string][]Language `json:"languages,omitempty"`
-	LintDebounce   time.Duration          `json:"lintDebounce,omitempty"`
-	FormatDebounce time.Duration          `json:"formatDebounce,omitempty"`
+	Languages *map[string][]Language `json:"languages,omitempty"`
+	// how long a document must be idle before it is linted
+	LintDebounce time.Duration `json:"lintDebounce,omitempty"`
 }
 
 type Language struct {

--- a/vendor/github.com/stretchr/testify/require/doc.go
+++ b/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,31 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// # Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//
+//	import (
+//	  "testing"
+//	  "github.com/stretchr/testify/require"
+//	)
+//
+//	func TestSomething(t *testing.T) {
+//
+//	  var a string = "Hello"
+//	  var b string = "Hello"
+//
+//	  require.Equal(t, a, b, "The two words should be the same.")
+//
+//	}
+//
+// # Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+// A consequence of this is that it must be called from the goroutine running
+// the test function, not from other goroutines created during the test.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require_forward.go.tmpl -include-format-funcs"

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,2180 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Condition(t, comp, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Conditionf(t, comp, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	require.Contains(t, "Hello World", "World")
+//	require.Contains(t, ["Hello", "World"], "World")
+//	require.Contains(t, {"Hello": "World"}, "Hello")
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Contains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Containsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Empty asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	require.Empty(t, obj)
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Empty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Emptyf asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	require.Emptyf(t, obj, "error message %s", "formatted")
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Emptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equal asserts that two objects are equal.
+//
+//	require.Equal(t, 123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equal(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	require.EqualError(t, err,  expectedErrorString)
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualError(t, theError, errString, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualErrorf(t, theError, errString, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	require.EqualValues(t, uint32(123), int32(123))
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	require.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equalf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	require.Error(t, err)
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Error(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	require.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContains(t, theError, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContainsf(t, theError, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	require.Errorf(t, err, "error message %s", "formatted")
+func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Errorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventually(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithT(t, func(c *require.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithT(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithTf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventuallyf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	require.Exactly(t, int32(123), int64(123))
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactly(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactlyf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Fail(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNow(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNowf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Failf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// False asserts that the specified value is false.
+//
+//	require.False(t, myBool)
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.False(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	require.Falsef(t, myBool, "error message %s", "formatted")
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Falsef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	require.Greater(t, 2, 1)
+//	require.Greater(t, float64(2), float64(1))
+//	require.Greater(t, "b", "a")
+func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greater(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	require.GreaterOrEqual(t, 2, 1)
+//	require.GreaterOrEqual(t, 2, 2)
+//	require.GreaterOrEqual(t, "b", "a")
+//	require.GreaterOrEqual(t, "b", "b")
+func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	require.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	require.Greaterf(t, "b", "a", "error message %s", "formatted")
+func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greaterf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCode(t, handler, method, url, values, statuscode, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCodef(t, handler, method, url, values, statuscode, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	require.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	require.InDelta(t, math.Pi, 22/7.0, 0.01)
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	require.IsDecreasing(t, []int{2, 1, 0})
+//	require.IsDecreasing(t, []float{2, 1})
+//	require.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	require.IsIncreasing(t, []int{1, 2, 3})
+//	require.IsIncreasing(t, []float{1, 2})
+//	require.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	require.IsNonDecreasing(t, []int{1, 1, 2})
+//	require.IsNonDecreasing(t, []float{1, 2})
+//	require.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	require.IsNonIncreasing(t, []int{2, 1, 1})
+//	require.IsNonIncreasing(t, []float{2, 1})
+//	require.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNotType asserts that the specified objects are not of the same type.
+//
+//	require.IsNotType(t, &NotMyStruct{}, &MyStruct{})
+func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNotType(t, theType, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNotTypef asserts that the specified objects are not of the same type.
+//
+//	require.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNotTypef(t, theType, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsType asserts that the specified objects are of the same type.
+//
+//	require.IsType(t, &MyStruct{}, &MyStruct{})
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsType(t, expectedType, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+//
+//	require.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsTypef(t, expectedType, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	require.Len(t, mySlice, 3)
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Len(t, object, length, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lenf(t, object, length, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Less asserts that the first element is less than the second
+//
+//	require.Less(t, 1, 2)
+//	require.Less(t, float64(1), float64(2))
+//	require.Less(t, "a", "b")
+func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Less(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	require.LessOrEqual(t, 1, 2)
+//	require.LessOrEqual(t, 2, 2)
+//	require.LessOrEqual(t, "a", "b")
+//	require.LessOrEqual(t, "b", "b")
+func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	require.Lessf(t, 1, 2, "error message %s", "formatted")
+//	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	require.Lessf(t, "a", "b", "error message %s", "formatted")
+func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lessf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negative asserts that the specified element is negative
+//
+//	require.Negative(t, -1)
+//	require.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negative(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	require.Negativef(t, -1, "error message %s", "formatted")
+//	require.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negativef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Never(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Neverf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	require.Nil(t, err)
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	require.Nilf(t, err, "error message %s", "formatted")
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.NoError(t, err) {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoError(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoErrorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	require.NotContains(t, "Hello World", "Earth")
+//	require.NotContains(t, ["Hello", "World"], "Earth")
+//	require.NotContains(t, {"Hello": "World"}, "Earth")
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContainsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmpty asserts that the specified object is NOT [Empty].
+//
+//	if require.NotEmpty(t, obj) {
+//	  require.Equal(t, "two", obj[1])
+//	}
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmpty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmptyf asserts that the specified object is NOT [Empty].
+//
+//	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  require.Equal(t, "two", obj[1])
+//	}
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	require.NotEqual(t, obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	require.NotEqualValues(t, obj1, obj2)
+func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	require.NotNil(t, err)
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	require.NotNilf(t, err, "error message %s", "formatted")
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	require.NotPanics(t, func(){ RemainCalm() })
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	require.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	require.NotSame(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSame(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSamef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubset asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.NotSubset(t, [1, 3, 4], [1, 2])
+//	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//	require.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
+//	require.NotSubset(t, {"x": 1, "y": 2}, ["z"])
+func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubsetf asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	require.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	require.Panics(t, func(){ GoCrazy() })
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithError(t, errString, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithErrorf(t, errString, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positive asserts that the specified element is positive
+//
+//	require.Positive(t, 1)
+//	require.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positive(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	require.Positivef(t, 1, "error message %s", "formatted")
+//	require.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positivef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	require.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	require.Same(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Same(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Samef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subset asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.Subset(t, [1, 2, 3], [1, 2])
+//	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//	require.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
+//	require.Subset(t, {"x": 1, "y": 2}, ["x"])
+func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subsetf asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	require.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// True asserts that the specified value is true.
+//
+//	require.True(t, myBool)
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.True(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Truef asserts that the specified value is true.
+//
+//	require.Truef(t, myBool, "error message %s", "formatted")
+func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Truef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRange(t, actual, start, end, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRangef(t, actual, start, end, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zero asserts that i is the zero value for its type.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zerof asserts that i is the zero value for its type.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}

--- a/vendor/github.com/stretchr/testify/require/require.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require.go.tmpl
@@ -1,0 +1,6 @@
+{{ replace .Comment "assert." "require."}}
+func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
+	if h, ok := t.(tHelper); ok { h.Helper() }
+	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }
+	t.FailNow()
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,1724 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Contains("Hello World", "World")
+//	a.Contains(["Hello", "World"], "World")
+//	a.Contains({"Hello": "World"}, "Hello")
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Containsf("Hello World", "World", "error message %s", "formatted")
+//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	a.Empty(obj)
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	a.Emptyf(obj, "error message %s", "formatted")
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//	a.Equal(123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualError(err,  expectedErrorString)
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValuesf(a.t, expected, actual, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValues(uint32(123), int32(123))
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	a.Error(err)
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Error(a.t, err, msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIsf(a.t, err, target, msg, args...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	a.Errorf(err, "error message %s", "formatted")
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Errorf(a.t, err, msg, args...)
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithT(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithT(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithTf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	a.Exactly(int32(123), int64(123))
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//	a.False(myBool)
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	a.Falsef(myBool, "error message %s", "formatted")
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExistsf(a.t, path, msg, args...)
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	a.Greater(2, 1)
+//	a.Greater(float64(2), float64(1))
+//	a.Greater("b", "a")
+func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greater(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqual(2, 1)
+//	a.GreaterOrEqual(2, 2)
+//	a.GreaterOrEqual("b", "a")
+//	a.GreaterOrEqual("b", "b")
+func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	a.Greaterf(2, 1, "error message %s", "formatted")
+//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//	a.Greaterf("b", "a", "error message %s", "formatted")
+func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greaterf(a.t, e1, e2, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	a.InDelta(math.Pi, 22/7.0, 0.01)
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	a.IsDecreasing([]int{2, 1, 0})
+//	a.IsDecreasing([]float{2, 1})
+//	a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	a.IsIncreasing([]int{1, 2, 3})
+//	a.IsIncreasing([]float{1, 2})
+//	a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasing([]int{1, 1, 2})
+//	a.IsNonDecreasing([]float{1, 2})
+//	a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	a.IsNonIncreasing([]int{2, 1, 1})
+//	a.IsNonIncreasing([]float{2, 1})
+//	a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNotType asserts that the specified objects are not of the same type.
+//
+//	a.IsNotType(&NotMyStruct{}, &MyStruct{})
+func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNotType(a.t, theType, object, msgAndArgs...)
+}
+
+// IsNotTypef asserts that the specified objects are not of the same type.
+//
+//	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNotTypef(a.t, theType, object, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+//
+//	a.IsType(&MyStruct{}, &MyStruct{})
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+//
+//	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	a.Len(mySlice, 3)
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	a.Lenf(mySlice, 3, "error message %s", "formatted")
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lenf(a.t, object, length, msg, args...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//	a.Less(1, 2)
+//	a.Less(float64(1), float64(2))
+//	a.Less("a", "b")
+func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Less(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqual(1, 2)
+//	a.LessOrEqual(2, 2)
+//	a.LessOrEqual("a", "b")
+//	a.LessOrEqual("b", "b")
+func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	a.Lessf(1, 2, "error message %s", "formatted")
+//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//	a.Lessf("a", "b", "error message %s", "formatted")
+func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//	a.Negative(-1)
+//	a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	a.Negativef(-1, "error message %s", "formatted")
+//	a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negativef(a.t, e, msg, args...)
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Never(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Neverf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	a.Nil(err)
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	a.Nilf(err, "error message %s", "formatted")
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nilf(a.t, object, msg, args...)
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExists(a.t, path, msgAndArgs...)
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExistsf(a.t, path, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoError(err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoErrorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoErrorf(a.t, err, msg, args...)
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExists(a.t, path, msgAndArgs...)
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExistsf(a.t, path, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContains("Hello World", "Earth")
+//	a.NotContains(["Hello", "World"], "Earth")
+//	a.NotContains({"Hello": "World"}, "Earth")
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
+func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT [Empty].
+//
+//	if a.NotEmpty(obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT [Empty].
+//
+//	if a.NotEmptyf(obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	a.NotEqual(obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValues(obj1, obj2)
+func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAsf(a.t, err, target, msg, args...)
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIsf(a.t, err, target, msg, args...)
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	a.NotImplements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	a.NotNil(err)
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	a.NotNilf(err, "error message %s", "formatted")
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanics(func(){ RemainCalm() })
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//	a.NotRegexp("^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	a.NotSame(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSame(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSamef(a.t, expected, actual, msg, args...)
+}
+
+// NotSubset asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.NotSubset([1, 3, 4], [1, 2])
+//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+//	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
+//	a.NotSubset({"x": 1, "y": 2}, ["z"])
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panics(func(){ GoCrazy() })
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithError(a.t, errString, f, msgAndArgs...)
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithErrorf(a.t, errString, f, msg, args...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//	a.Positive(1)
+//	a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	a.Positivef(1, "error message %s", "formatted")
+//	a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positivef(a.t, e, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	a.Regexp(regexp.MustCompile("start"), "it's starting")
+//	a.Regexp("start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	a.Same(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Same(a.t, expected, actual, msgAndArgs...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Samef(a.t, expected, actual, msg, args...)
+}
+
+// Subset asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.Subset([1, 2, 3], [1, 2])
+//	a.Subset({"x": 1, "y": 2}, {"x": 1})
+//	a.Subset([1, 2, 3], {1: "one", 2: "two"})
+//	a.Subset({"x": 1, "y": 2}, ["x"])
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//	a.True(myBool)
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//	a.Truef(myBool, "error message %s", "formatted")
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRange(a.t, actual, start, end, msgAndArgs...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRangef(a.t, actual, start, end, msg, args...)
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEqf(a.t, expected, actual, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zerof(a.t, i, msg, args...)
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
@@ -1,0 +1,5 @@
+{{.CommentWithoutT "a"}}
+func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) {
+	if h, ok := a.t.(tHelper); ok { h.Helper() }
+	{{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
+}

--- a/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,29 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+type tHelper = interface {
+	Helper()
+}
+
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{})
+
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{})
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -72,6 +72,7 @@ github.com/spf13/pflag
 ## explicit; go 1.17
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/assert/yaml
+github.com/stretchr/testify/require
 # github.com/tcnksm/ghr v0.17.0
 ## explicit; go 1.23
 github.com/tcnksm/ghr


### PR DESCRIPTION
  # Fix data races and request handling in the LSP layer

  ## Why

  The server shared mutable document state between the connection's read loop and
  its lint/format goroutines with no synchronisation. Under `-race` that is a
  diagnosed data race; in production it can panic with `concurrent map read and
  map write`. Fixing it surfaced a cluster of related correctness problems in the
  same layer, all addressed here.

  ## Concurrency

    `documentSnapshot` (the `fileRef` by value, plus the configs map and root path)
    under an `RWMutex`, then run entirely outside it — no subprocess and no
    root-marker filesystem walk happens while the lock is held. `rootPath` is
    unexported so all mutable state is private.
  - **Linting is debounced per document.** A single shared `time.Timer` meant the
    pending run captured whichever document scheduled it first; scheduling for a
    second document merely `Reset` that timer, so the second document was never
    linted while the first was linted twice. Now one job per document, each with
    its own timer, cancellation and generation counter.
  - **Timer state is no longer racy.** The old `lintTimer`/`formatTimer` fields were
    read outside the mutex and written from inside the timer callback, and `Reset`
    on an already-fired timer could start two concurrent runs for one document.
  - **Lint contexts are released.** The package-level `running` map was never
    deleted from, leaking one live `context.WithCancel` per file opened for the
    process lifetime. Jobs are dropped once nothing is scheduled, and `didClose`
    drops them eagerly.
  - **Jobs are matched by identity, not just generation.** Closing a document drops
    its job and the one installed on reopen counts from 1 again, so a run left over
    from before the close could match the new job and evict it mid-flight — leaking
    that run's context and breaking coalescing for the document.

  ## Formatting

  - **Removed the format debounce.** `textDocument/formatting` is a request whose
    response the editor applies; returning `[]TextEdit{}` inside the debounce
    window told the client *"this document needs no changes"*, so format-on-save
    followed by a manual format silently did nothing. Because `formatDebounce`
    defaulted to `0` the guard also almost never engaged — it only ever affected
    people who set the knob, and cost them a wrong answer per suppressed request.
  - **Replaced it with supersession.** A request that finds a newer request queued
    for the same document returns `ContentModified` (-32801) rather than shelling
    out, since its edits would be stale by construction. A burst of 100 formats
    costs one run instead of 100, every request still gets a truthful answer, and
    there is no interval to tune.
  - **Documents format in parallel.** Exclusion is per document. Two runs on one
    file would diff against the same original text, and in-place formatters would
    fight over it — but unrelated files share nothing, and linting already runs
    fully parallel across documents.
  - **Stale edits are rejected.** Formatting returns a diff against the text the run
    started from, so it only applies cleanly to a document that has not moved. A
    synchronous client (the usual default, e.g. neovim's
    `vim.lsp.buf.format({async = false})`) blocks input and cannot hit this; an
    asynchronous one can, and applying a stale diff would corrupt the buffer. The
    version is re-checked before the edits are returned and a race is reported as
    `ContentModified`. Cheap insurance, not a fix for something well-behaved
    clients trip over.

  **Breaking:** `formatDebounce` is gone from the config. Clients still sending it
  are unaffected (unknown JSON fields are ignored). `lintDebounce` now defaults to
  100ms rather than 0.

  ## Protocol

  - **`shutdown`/`exit` follow the spec.** `shutdown` used to close the connection
    itself, racing its own response and leaving no way to deliver `exit`. It now
    stops outstanding work and replies; a new `exit` handler closes the connection.
    Requests after `shutdown` get `InvalidRequest`, and the process exits 1 only
    when `exit` arrives without a preceding `shutdown` — a connection that simply
    goes away is not an error.
  - **Slow requests no longer block the read loop.** Formatting ran inline, so the
    server processed no other message — not `didChange`, not `didClose` — until the
    external formatter exited. Formatting now runs in its own goroutine.
    Deliberately *not* a blanket async handler: that reorders messages relative to
    notifications, which breaks document-sync ordering and lets a pipelined `exit`
    overtake `shutdown` (caught while testing this).
  - **`didSave` reports a save.** It previously reported `EventTypeChange` when the
    client did not include the text, so `lintOnSave`/`lintOnChange` fired on the
    wrong event.
  - **Progress tokens always close.** A formatting run in which every formatter
    failed returned without its progress `end`, leaving a spinner up forever.

  ## Cleanup

  - Replaced the 3 channels and 3 pump goroutines created per lint run with a
    `core.Reporter` interface that `*LspNotifier` implements — removes ~35 lines of
    plumbing, the send-after-close hazards, and 3 goroutines per keystroke batch.
  - Extracted `decodeParams[T]`, removing identical params-decoding boilerplate
    from seven handlers.
  - `didChange` applies only the last content change (sync kind is Full, so the
    earlier ones are redundant).
  - The notifier logs dropped notifications instead of discarding the error, so a
    dead connection or cancelled run is visible.
  - Removed dead code in `main.go` (a `defer` closing an always-nil file) and a
    test-only helper living in non-test code; `core.NewHandler` no longer
    nil-derefs on a config without languages; fixed a debug log printing the wrong
    field.

  ## Tests

  `lsp` had no tests at all despite holding the trickiest code in the repo. Added
  21 across `lsp` and `core`, covering per-document scheduling and supersession,
  job release and identity, cancel/close, shutdown/exit sequencing, param decoding,
  inline-vs-offloaded dispatch, and document sync racing concurrent lint runs.

  Each test written for a fixed bug was verified to fail against the old
  behaviour:

  | Change reverted | Result |
  |---|---|
  | `LangHandler` locking | concurrency test reports 9 data races |
  | per-document format lock → global | parallelism test fails in 12.45s |
  | job identity check | reopened-document test fails |
  | post-format version check | stale edits reach the client |

  Tests avoid timing assumptions: the supersession test holds the document's job
  lock so exactly one run is possible, and the parallelism and stale-edit tests use
  shell barriers so the interleaving is forced rather than hoped for. The two
  barrier-based tests are POSIX-only and skipped on Windows; everything else runs
  on all platforms.

  `gofmt`, `go vet` and `golangci-lint run ./...` are clean; `go test -race
  -count=3 ./...` passes. Also exercised end-to-end by driving the real binary over
  stdio: 20 rapid edits across 2 documents collapse to 2 lint runs (one per
  document), formatting returns edits computed from the latest text, clean exit,
  no races.

  ## Not included

  - `$/cancelRequest` is still unhandled, so a client cannot withdraw a queued
    request and an in-flight formatter is not killed on shutdown. Supersession
    makes this largely moot for formatting; a proper fix needs per-request
    contexts and belongs in its own change.
  - There is no global cap on concurrent linter/formatter subprocesses, so
    formatting 50 open files spawns 50 processes. Linting has always behaved this
    way. If it ever bites, the fix is one semaphore covering both, not a lock that
    pretends unrelated files conflict.

  Note: `vendor/github.com/stretchr/testify/require` is newly vendored (tests
  only); `go.mod` is unchanged.